### PR TITLE
新キャラStretchのデモ

### DIFF
--- a/Assets/Script/enemy/Stretch.cs
+++ b/Assets/Script/enemy/Stretch.cs
@@ -1,0 +1,46 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using static UnityEngine.EventSystems.EventTrigger;
+
+
+public class Stretch : MonoBehaviour
+{
+    private Rigidbody2D rb;
+    private Enemy enemy;
+
+    [Header("変更後のサイズ")]
+    [SerializeField] float newScalse = 5f;
+    [SerializeField] float nomalScale = 1f;
+
+    bool normal = true;
+
+    void Start()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        enemy = GetComponent<Enemy>();
+
+        rb.constraints |= RigidbodyConstraints2D.FreezePositionX;
+        rb.constraints |= RigidbodyConstraints2D.FreezePositionY;
+        rb.constraints |= RigidbodyConstraints2D.FreezeRotation;
+    }
+
+    // Update is called once per frame
+    private void FixedUpdate()
+    {
+        if (!enemy.IsDetected && enemy.DetectedPlayer == null)
+        {
+            if (!normal)
+            {
+                transform.localScale = new Vector3(nomalScale, nomalScale, nomalScale);
+            }
+        }
+        else if (enemy.IsDetected && enemy.DetectedPlayer != null)
+        {
+            transform.localScale = new Vector3(newScalse, newScalse, newScalse);
+            normal = false;
+        }
+    }
+
+
+}

--- a/Assets/Script/enemy/Stretch.cs.meta
+++ b/Assets/Script/enemy/Stretch.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0d24c6d9f4172804b8c919a7e5a8c2b4


### PR DESCRIPTION
索敵範囲にプレイヤーを検知したら体を伸ばして攻撃する新キャラStretchのデモです。
現在の機能は
- プレイヤーを検知したら体を大きくする
- プレイヤーを見失ったら元のサイズに戻る
の二つです。

後々体全体を大きくするのではなく、プレイヤーの方向にのみ大きくできるように設計します。